### PR TITLE
#158720153 As a user I should be able to see pre-populated input fields after clicking edit for a business on the list.

### DIFF
--- a/src/components/editbusiness.js
+++ b/src/components/editbusiness.js
@@ -94,21 +94,21 @@ export class Editbusiness extends Component {
 								<div className="form-group">
 									<label className="control-label col-sm-2" htmlFor="businessname">Name:</label>
 									<div className="col-sm-10">
-										<input className="form-control" defaultValue={this.state.currentBusiness.name} name="name" placeholder="Business Name" id="businessname" maxLength="100" size="100"/>
+										<input className="form-control" value={this.state.currentBusiness.name} onChange={this.handleEdit} name="name" placeholder="Business Name" id="businessname" maxLength="100" size="100"/>
 									</div>
 								</div>
 								
 								<div className="form-group">
 									<label className="control-label col-sm-2" htmlFor="businesslocation">Location:</label>
 									<div className="col-sm-10">
-										<input className="form-control" defaultValue={this.state.currentBusiness.location} name="location" placeholder="Business Location" id="businesslocation" maxLength="100" size="100"/>
+										<input className="form-control" value={this.state.currentBusiness.location} onChange={this.handleEdit} name="location" placeholder="Business Location" id="businesslocation" maxLength="100" size="100"/>
 									</div>
 								</div>
 								
 								<div className="form-group">
 									<label className="control-label col-sm-2" htmlFor="businesscategory">Category:</label>
 									<div className="col-sm-10">
-										<input className="form-control" defaultValue={this.state.currentBusiness.category} name="category" placeholder="Business Category" id="businesscategory" maxLength="100" size="100"/>
+										<input className="form-control" value={this.state.currentBusiness.category} onChange={this.handleEdit} name="category" placeholder="Business Category" id="businesscategory" maxLength="100" size="100"/>
 									</div>
 								</div>
 								


### PR DESCRIPTION
**What does this PR do?**

Allows the edit form to have fields prepopulated with values

**Description of Task to be completed?**

When the edit button on the list of businesses is clicked it should be able to display a form with default values in the input fields. It should also allow for the input fields to be edited.

**How should this be manually tested?**

After clicking the edit button on the list of business, a form pre-populated with business values will be displayed.

**Any background context you want to provide?**

This pull request attempts to address some issues encountered when editing a business.

**What are the relevant pivotal tracker stories?**

[#158720153](https://www.pivotaltracker.com/story/show/158720153)
